### PR TITLE
Workaround patch for QEMU

### DIFF
--- a/qemu_mode/patches/syscall.diff
+++ b/qemu_mode/patches/syscall.diff
@@ -2,9 +2,10 @@ diff --git a/linux-user/syscall.c b/linux-user/syscall.c
 index 280137da..8c0e749f 100644
 --- a/linux-user/syscall.c
 +++ b/linux-user/syscall.c
-@@ -112,6 +112,8 @@
+@@ -112,6 +112,9 @@
  #include "qemu.h"
  #include "fd-trans.h"
++#include <linux/sockios.h>
  
 +extern unsigned int afl_forksrv_pid;
 +


### PR DESCRIPTION
On Ubuntu 19.10 the QEMU mode didn't compile for me. 

The patch in this pull request (just an additional include) fixed the issue for me. This was taken from https://lists.sr.ht/~philmd/qemu/patches/6224#%3C20190617114005.24603-1-berrange@redhat.com%3E+linux-user/syscall.c

QEMU mode works for me like that.

However, the following patch is much bigger and would make it a little more robust I guess: https://patchwork.kernel.org/patch/11049817/

I didn't implement that though...

I don't know if you want to use this workaround for now or if you want to update to a newer QEMU version or whatever...