### PR TITLE
Qemu neverzero

### DIFF
--- a/config.h
+++ b/config.h
@@ -339,6 +339,10 @@
 #define  CTEST_CORE_TRG_MS  1000
 #define  CTEST_BUSY_CYCLES  (10 * 1000 * 1000)
 
+/* Enable NeverZero counters in QEMU mode */
+
+#define AFL_QEMU_NOT_ZERO
+
 /* Uncomment this to use inferior block-coverage-based instrumentation. Note
    that you need to recompile the target binary for this to have any effect: */
 

--- a/qemu_mode/patches/afl-qemu-translate-inl.h
+++ b/qemu_mode/patches/afl-qemu-translate-inl.h
@@ -46,7 +46,7 @@ void afl_maybe_log(target_ulong cur_loc) {
 
   static __thread abi_ulong prev_loc;
 
-  register target_ulong afl_idx = cur_loc ^ prev_loc;
+  register uintptr_t afl_idx = cur_loc ^ prev_loc;
 
 #if (defined(__x86_64__) || defined(__i386__)) && defined(AFL_QEMU_NOT_ZERO)
   asm volatile (

--- a/unicorn_mode/build_unicorn_support.sh
+++ b/unicorn_mode/build_unicorn_support.sh
@@ -144,7 +144,7 @@ echo "[+] Configuration complete."
 
 echo "[*] Attempting to build Unicorn (fingers crossed!)..."
 
-UNICORN_QEMU_FLAGS='--python=python2' make || exit 1
+UNICORN_QEMU_FLAGS='--python=python2' make -j `nproc` || exit 1
 
 echo "[+] Build process successful!"
 


### PR DESCRIPTION
I added neverzero counters for qemu_mode and unicorn_mode when compiled for x86 and x86_64.
Doing some tests results that showmap logs more coverage in this way (it is correct?).
Execution speed is almost the same.

However IMO this needs some other tests before merge.

Neverzero for both QEMU and Unicorn can be disabled commenting the `#define AFL_QEMU_NOT_ZERO` line in config.h.