### PR TITLE
Fixed SIGSEV due to wrong pointer size

### DIFF
--- a/qemu_mode/patches/afl-qemu-cpu-translate-inl.h
+++ b/qemu_mode/patches/afl-qemu-cpu-translate-inl.h
@@ -49,7 +49,7 @@ void tcg_gen_afl_compcov_log_call(void *func, target_ulong cur_loc,
 #  define INC_AFL_AREA(loc) \
     asm volatile ( \
       "incb (%0, %1, 1)\n" \
-      "adc $0, (%0, %1, 1)\n" \
+      "adcb $0, (%0, %1, 1)\n" \
       : /* no out */ \
       : "r" (afl_area_ptr), "r" (loc) \
       : "memory", "eax" \

--- a/qemu_mode/patches/afl-qemu-translate-inl.h
+++ b/qemu_mode/patches/afl-qemu-translate-inl.h
@@ -51,7 +51,7 @@ void afl_maybe_log(target_ulong cur_loc) {
 #if (defined(__x86_64__) || defined(__i386__)) && defined(AFL_QEMU_NOT_ZERO)
   asm volatile (
     "incb (%0, %1, 1)\n"
-    "adc $0, (%0, %1, 1)\n"
+    "adcb $0, (%0, %1, 1)\n"
     : /* no out */
     : "r" (afl_area_ptr), "r" (afl_idx)
     : "memory", "eax"

--- a/unicorn_mode/patches/afl-unicorn-cpu-inl.h
+++ b/unicorn_mode/patches/afl-unicorn-cpu-inl.h
@@ -252,7 +252,7 @@ static inline void afl_maybe_log(struct uc_struct* uc, unsigned long cur_loc) {
 #if (defined(__x86_64__) || defined(__i386__)) && defined(AFL_QEMU_NOT_ZERO)
   asm volatile (
     "incb (%0, %1, 1)\n"
-    "adc $0, (%0, %1, 1)\n"
+    "adcb $0, (%0, %1, 1)\n"
     : /* no out */
     : "r" (uc->afl_area_ptr), "r" (afl_idx)
     : "memory", "eax"

--- a/unicorn_mode/patches/afl-unicorn-tcg-runtime-inl.h
+++ b/unicorn_mode/patches/afl-unicorn-tcg-runtime-inl.h
@@ -36,7 +36,7 @@
 #  define INC_AFL_AREA(loc) \
     asm volatile ( \
       "incb (%0, %1, 1)\n" \
-      "adc $0, (%0, %1, 1)\n" \
+      "adcb $0, (%0, %1, 1)\n" \
       : /* no out */ \
       : "r" (uc->afl_area_ptr), "r" (loc) \
       : "memory", "eax" \


### PR DESCRIPTION
@andreafioraldi this fixes the SIGSEV in your current branch. 
It happened when the pointer was close to `MAP_SIZE` as it would try to read multiple bytes (out of bounds)
When it comes to memory safety, assembler is not much better than c :D

Thix fixes the issue discussed in #50 