### PR TITLE
Build statically-linked binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,15 @@ else
 	PYFLAGS=
 endif
 
+ifdef STATIC
+  $(info Compiling static version of binaries)
+  # Disable python for static compilation to simplify things
+  PYTHON_OK=0
+  PYFLAGS=
+
+  CFLAGS += -static
+  LDFLAGS += -lm -lrt -lpthread -lz -lutil
+endif
 
 ifeq "$(shell echo '\#include <sys/ipc.h>@\#include <sys/shm.h>@int main() { int _id = shmget(IPC_PRIVATE, 65536, IPC_CREAT | IPC_EXCL | 0600); shmctl(_id, IPC_RMID, 0); return 0;}' | tr @ '\n' | $(CC) -x c - -o .test2 2>/dev/null && echo 1 || echo 0 )" "1"
 	SHMAT_OK=1
@@ -175,7 +184,7 @@ src/afl-sharedmem.o : src/afl-sharedmem.c include/sharedmem.h
 	$(CC) $(CFLAGS) -c src/afl-sharedmem.c -o src/afl-sharedmem.o
 
 afl-fuzz: include/afl-fuzz.h $(AFL_FUZZ_FILES) src/afl-common.o src/afl-sharedmem.o src/afl-forkserver.o $(COMM_HDR) | test_x86
-	$(CC) $(CFLAGS) $(AFL_FUZZ_FILES) src/afl-common.o src/afl-sharedmem.o src/afl-forkserver.o -o $@ $(LDFLAGS) $(PYFLAGS)
+	$(CC) $(CFLAGS) $(AFL_FUZZ_FILES) src/afl-common.o src/afl-sharedmem.o src/afl-forkserver.o -o $@ $(PYFLAGS) $(LDFLAGS)
 
 afl-showmap: src/afl-showmap.c src/afl-common.o src/afl-sharedmem.o $(COMM_HDR) | test_x86
 	$(CC) $(CFLAGS) src/$@.c src/afl-common.o src/afl-sharedmem.o -o $@ $(LDFLAGS)

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ These build options exist:
 * clean: cleans everything. for qemu_mode and unicorn_mode it means it deletes all downloads as well
 * help: shows these build options
 
+You can also build statically linked versions of the afl++ binaries by passing the STATIC=1 argument to make:
+
+```shell
+$ make all STATIC=1
+```
+
 
 ## 1) Challenges of guided fuzzing
 

--- a/qemu_mode/README.md
+++ b/qemu_mode/README.md
@@ -38,7 +38,13 @@ to 200 MB when specifying -Q to afl-fuzz; be careful when overriding this.
 In principle, if you set CPU_TARGET before calling ./build_qemu_support.sh,
 you should get a build capable of running non-native binaries (say, you
 can try CPU_TARGET=arm). This is also necessary for running 32-bit binaries
-on a 64-bit system (CPU_TARGET=i386).
+on a 64-bit system (CPU_TARGET=i386). If you're trying to run QEMU on a
+different architecture you can also set HOST to the cross-compiler prefix
+to use (for example HOST=arm-linux-gnueabi to use arm-linux-gnueabi-gcc).
+
+You can also compile statically-linked binaries by setting STATIC=1. This
+can be useful when compiling QEMU on a different system than the one you're
+planning to run the fuzzer on and is most often used with the HOST variable.
 
 Note: if you want the QEMU helper to be installed on your system for all
 users, you need to build it before issuing 'make install' in the parent

--- a/qemu_mode/build_qemu_support.sh
+++ b/qemu_mode/build_qemu_support.sh
@@ -154,7 +154,17 @@ echo "[+] Patching done."
 
 if [ "$STATIC" -eq "1" ]; then
 
-  CFLAGS="-O3 -ggdb" ./configure --disable-bsd-user --disable-guest-agent --disable-strip --disable-werror --disable-gcrypt --disable-debug-info --disable-debug-tcg --enable-docs --disable-tcg-interpreter --enable-attr --disable-brlapi --disable-linux-aio --disable-bzip2 --disable-bluez --disable-cap-ng --disable-curl --disable-fdt --disable-glusterfs --disable-gnutls --disable-nettle --disable-gtk --disable-rdma --disable-libiscsi --disable-vnc-jpeg --enable-kvm --disable-lzo --disable-curses --disable-libnfs --disable-numa --disable-opengl --disable-vnc-png --disable-rbd --disable-vnc-sasl --disable-sdl --disable-seccomp --disable-smartcard --disable-snappy --disable-spice --disable-libssh2 --disable-libusb --disable-usb-redir --disable-vde --disable-vhost-net --disable-virglrenderer --disable-virtfs --disable-vnc --disable-vte --disable-xen --disable-xen-pci-passthrough --disable-xfsctl --enable-linux-user --disable-system --disable-blobs --disable-tools --target-list="${CPU_TARGET}-linux-user" --static --disable-pie --cross-prefix=$CROSS_PREFIX || exit 1
+  CFLAGS="-O3 -ggdb" ./configure --disable-bsd-user --disable-guest-agent --disable-strip --disable-werror \
+	  --disable-gcrypt --disable-debug-info --disable-debug-tcg --enable-docs --disable-tcg-interpreter \
+	  --enable-attr --disable-brlapi --disable-linux-aio --disable-bzip2 --disable-bluez --disable-cap-ng \
+	  --disable-curl --disable-fdt --disable-glusterfs --disable-gnutls --disable-nettle --disable-gtk \
+	  --disable-rdma --disable-libiscsi --disable-vnc-jpeg --enable-kvm --disable-lzo --disable-curses \
+	  --disable-libnfs --disable-numa --disable-opengl --disable-vnc-png --disable-rbd --disable-vnc-sasl \
+	  --disable-sdl --disable-seccomp --disable-smartcard --disable-snappy --disable-spice --disable-libssh2 \
+	  --disable-libusb --disable-usb-redir --disable-vde --disable-vhost-net --disable-virglrenderer \
+	  --disable-virtfs --disable-vnc --disable-vte --disable-xen --disable-xen-pci-passthrough --disable-xfsctl \
+	  --enable-linux-user --disable-system --disable-blobs --disable-tools \
+	  --target-list="${CPU_TARGET}-linux-user" --static --disable-pie --cross-prefix=$CROSS_PREFIX || exit 1
 
 else
 

--- a/src/afl-fuzz-run.c
+++ b/src/afl-fuzz-run.c
@@ -178,7 +178,16 @@ u8 run_target(char** argv, u32 timeout) {
     if ((res = read(fsrv_st_fd, &status, 4)) != 4) {
 
       if (stop_soon) return 0;
-      RPFATAL(res, "Unable to communicate with fork server (OOM?)");
+      SAYF("\n" cLRD "[-] " cRST
+           "Unable to communicate with fork server. Some possible reasons:\n\n" 
+           "    - You've run out of memory. Use -m to increase the the memory limit\n"
+           "      to something higher than %lld.\n"
+           "    - The binary or one of the libraries it uses manages to create\n"
+           "      threads before the forkserver initializes.\n"
+           "    - The binary, at least in some circumstances, exits in a way that\n"
+           "      also kills the parent process - raise() could be the culprit.\n\n"
+	   "If all else fails you can disable the fork server via AFL_NO_FORKSRV=1.\n", mem_limit);
+      RPFATAL(res, "Unable to communicate with fork server");
 
     }
 


### PR DESCRIPTION
These are changes that should help with fuzzing closed-source embedded devices.

* Adds support for statically compiling both AFL and QEMU binaries
* Improved error message when unable to reach the fork server
* Related documentation updates