### PR TITLE
No Longer Warns for Absolute Binaries for Unicorn

### DIFF
--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -554,7 +554,7 @@ int main(int argc, char** argv) {
   if (getenv("AFL_NO_UI") && getenv("AFL_FORCE_UI"))
     FATAL("AFL_NO_UI and AFL_FORCE_UI are mutually exclusive");
 
-  if (strchr(argv[optind], '/') == NULL)
+  if (strchr(argv[optind], '/') == NULL && !unicorn_mode)
     WARNF(cLRD
           "Target binary called without a prefixed path, make sure you are "
           "fuzzing the right binary: " cRST "%s",


### PR DESCRIPTION
This fixes a minor incovenience:
When running unicorn mode, we will usually call the python interpreter as actual binary.
This may point to the python in the PATH, which is correct. No need to nag the user :)