### PR TITLE
LLVM mode passing the full path of the LLVM config bindir.

### DIFF
--- a/llvm_mode/Makefile
+++ b/llvm_mode/Makefile
@@ -52,7 +52,7 @@ endif
 CFLAGS      ?= -O3 -funroll-loops
 CFLAGS      += -Wall -D_FORTIFY_SOURCE=2 -g -Wno-pointer-sign -I ../include/ \
                -DAFL_PATH=\"$(HELPER_PATH)\" -DBIN_PATH=\"$(BIN_PATH)\" \
-               -DVERSION=\"$(VERSION)\"
+               -DLLVM_BINDIR=\"$(LLVM_BINDIR)\" -DVERSION=\"$(VERSION)\"
 ifdef AFL_TRACE_PC
   CFLAGS    += -DUSE_TRACE_PC=1
 endif

--- a/llvm_mode/afl-clang-fast.c
+++ b/llvm_mode/afl-clang-fast.c
@@ -32,11 +32,13 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 #include <assert.h>
 
 static u8*  obj_path;                  /* Path to runtime libraries         */
 static u8** cc_params;                 /* Parameters passed to the real CC  */
 static u32  cc_par_cnt = 1;            /* Param count, including argv0      */
+static u8  llvm_fullpath[PATH_MAX];
 
 /* Try to find the runtime libraries. If that fails, abort. */
 
@@ -117,12 +119,14 @@ static void edit_params(u32 argc, char** argv) {
   if (!strcmp(name, "afl-clang-fast++")) {
 
     u8* alt_cxx = getenv("AFL_CXX");
-    cc_params[0] = alt_cxx ? alt_cxx : (u8*)"clang++";
+    snprintf(llvm_fullpath, sizeof(llvm_fullpath), "%s/clang++", LLVM_BINDIR);
+    cc_params[0] = alt_cxx ? alt_cxx : (u8*)llvm_fullpath;
 
   } else {
 
     u8* alt_cc = getenv("AFL_CC");
-    cc_params[0] = alt_cc ? alt_cc : (u8*)"clang";
+    snprintf(llvm_fullpath, sizeof(llvm_fullpath), "%s/clang", LLVM_BINDIR);
+    cc_params[0] = alt_cc ? alt_cc : (u8*)llvm_fullpath;
 
   }
 

--- a/llvm_mode/afl-clang-fast.c
+++ b/llvm_mode/afl-clang-fast.c
@@ -38,7 +38,7 @@
 static u8*  obj_path;                  /* Path to runtime libraries         */
 static u8** cc_params;                 /* Parameters passed to the real CC  */
 static u32  cc_par_cnt = 1;            /* Param count, including argv0      */
-static u8  llvm_fullpath[PATH_MAX];
+static u8   llvm_fullpath[PATH_MAX];
 
 /* Try to find the runtime libraries. If that fails, abort. */
 
@@ -106,6 +106,7 @@ static void find_obj(u8* argv0) {
 static void edit_params(u32 argc, char** argv) {
 
   u8  fortify_set = 0, asan_set = 0, x_set = 0, maybe_linking = 1, bit_mode = 0;
+  u8  has_llvm_config = 0;
   u8* name;
 
   cc_params = ck_alloc((argc + 128) * sizeof(u8*));
@@ -116,16 +117,20 @@ static void edit_params(u32 argc, char** argv) {
   else
     ++name;
 
+  has_llvm_config = (strlen(LLVM_BINDIR) > 0);
+
   if (!strcmp(name, "afl-clang-fast++")) {
 
     u8* alt_cxx = getenv("AFL_CXX");
-    snprintf(llvm_fullpath, sizeof(llvm_fullpath), "%s/clang++", LLVM_BINDIR);
+    if (has_llvm_config)  snprintf(llvm_fullpath, sizeof(llvm_fullpath), "%s/clang++", LLVM_BINDIR);
+    else sprintf(llvm_fullpath, "clang++");
     cc_params[0] = alt_cxx ? alt_cxx : (u8*)llvm_fullpath;
 
   } else {
 
     u8* alt_cc = getenv("AFL_CC");
-    snprintf(llvm_fullpath, sizeof(llvm_fullpath), "%s/clang", LLVM_BINDIR);
+    if (has_llvm_config)  snprintf(llvm_fullpath, sizeof(llvm_fullpath), "%s/clang", LLVM_BINDIR);
+    else sprintf(llvm_fullpath, "clang");
     cc_params[0] = alt_cc ? alt_cc : (u8*)llvm_fullpath;
 
   }


### PR DESCRIPTION
On FreeBSD the system compiler does not have llvm-config
however system packages provides several version of the
LLVM toolchain thus forcing to pass AFL_CC/AFL_CXX to make
it work fully.