### PR TITLE
gcc plugin little update proposal.

### DIFF
--- a/gcc_plugin/Makefile
+++ b/gcc_plugin/Makefile
@@ -80,7 +80,7 @@ test_deps:
 	@echo "[+] All set and ready to build."
 
 ../afl-gcc-fast: afl-gcc-fast.c | test_deps
-	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+	$(CC) -DAFL_GCC_CC=\"$(CC)\" -DAFL_GCC_CXX=\"$(CXX)\" $(CFLAGS) $< -o $@ $(LDFLAGS)
 	ln -sf afl-gcc-fast ../afl-g++-fast
 
 ../afl-gcc-pass.so: afl-gcc-pass.so.cc | test_deps

--- a/gcc_plugin/README.gcc.md
+++ b/gcc_plugin/README.gcc.md
@@ -46,9 +46,11 @@ should be all you need. On Debian machines, these headers can be acquired by
 installing the `gcc-<VERSION>-plugin-dev` packages.
 
 To build the instrumentation itself, type 'make'. This will generate binaries
-called afl-gcc-fast and afl-g++-fast in the parent directory. Once this
-is done, you can instrument third-party code in a way similar to the standard
-operating mode of AFL, e.g.:
+called afl-gcc-fast and afl-g++-fast in the parent directory. 
+If the CC/CXX have been overridden, those compilers will be used from
+those wrappers without using AFL_CXX/AFL_CC settings.
+Once this is done, you can instrument third-party code in a way similar to the
+standard operating mode of AFL, e.g.:
 
   CC=/path/to/afl/afl-gcc-fast ./configure [...options...]
   make

--- a/gcc_plugin/afl-gcc-fast.c
+++ b/gcc_plugin/afl-gcc-fast.c
@@ -119,12 +119,12 @@ static void edit_params(u32 argc, char** argv) {
   if (!strcmp(name, "afl-g++-fast")) {
 
     u8* alt_cxx = getenv("AFL_CXX");
-    cc_params[0] = alt_cxx ? alt_cxx : (u8*)"g++";
+    cc_params[0] = alt_cxx ? alt_cxx : (u8*)AFL_GCC_CXX;
 
   } else {
 
     u8* alt_cc = getenv("AFL_CC");
-    cc_params[0] = alt_cc ? alt_cc : (u8*)"gcc";
+    cc_params[0] = alt_cc ? alt_cc : (u8*)AFL_GCC_CC;
 
   }
 


### PR DESCRIPTION
like its llvm counterpart, passing the compiler chain used
to avoid using necessarily AFL_CC/AFL_CXX.