### PR TITLE
Fix unicorn build error on macOS

### DIFF
--- a/unicorn_mode/build_unicorn_support.sh
+++ b/unicorn_mode/build_unicorn_support.sh
@@ -198,7 +198,7 @@ echo "[*] Installing Unicorn python bindings..."
 cd bindings/python || exit 1
 if [ -z "$VIRTUAL_ENV" ]; then
   echo "[*] Info: Installing python unicorn using --user"
-  $PYTHONBIN setup.py install --user || exit 1
+  $PYTHONBIN setup.py install --user  --prefix=|| exit 1
 else
   echo "[*] Info: Installing python unicorn to virtualenv: $VIRTUAL_ENV"
   $PYTHONBIN setup.py install || exit 1


### PR DESCRIPTION
When building on macOS I get the following error:
```
[*] Info: Installing python unicorn using --user
running install
error: can't combine user with prefix, exec_prefix/home, or install_(plat)base
make: *** [osx-only] Error 1
```
Which relates to the following line of the build script [Line 201](https://github.com/vanhauser-thc/AFLplusplus/blob/master/unicorn_mode/build_unicorn_support.sh#L201):
```sh
$PYTHONBIN setup.py install --user || exit 1
```
It seems to be a known problem (https://stackoverflow.com/questions/4495120/combine-user-with-prefix-error-with-setup-py-install) which can be fixed by passing `--prefix=` option to the `setup.py` invocation. 

Tested on: macOS Catalina 10.15 / Python 2.7.15 (default, Feb  1 2019, 09:46:00)