### PR TITLE
minor fix for llvm_mode build with non-standard paths

### DIFF
--- a/llvm_mode/Makefile
+++ b/llvm_mode/Makefile
@@ -136,8 +136,8 @@ else
 endif
 
 ifneq "$(CLANGVER)" "$(LLVMVER)"
-  CC = $(shell llvm-config --bindir)/clang
-  CXX = $(shell llvm-config --bindir)/clang++
+  CC = $(shell $(LLVM_CONFIG) --bindir)/clang
+  CXX = $(shell $(LLVM_CONFIG) --bindir)/clang++
 endif
 
 # If prerequisites are not given, warn, do not build anything, and exit with code 0


### PR DESCRIPTION
plus cleanup of the unicorn submodule.

I'm not sure if the version checking logic in llvm_mode/Makefile still makes sense after 123d97bfb896aefca24ff8bdc235b900fe714fde - but at least it should use the same llvm-config.