### PR TITLE
add AFL_USE_UBSAN

### DIFF
--- a/llvm_mode/afl-clang-fast.c
+++ b/llvm_mode/afl-clang-fast.c
@@ -299,6 +299,14 @@ static void edit_params(u32 argc, char** argv) {
       cc_params[cc_par_cnt++] = "-fsanitize=memory";
 
     }
+    
+    if (getenv("AFL_USE_UBSAN")) {
+    
+      cc_params[cc_par_cnt++] = "-fsanitize=undefined";
+      cc_params[cc_par_cnt++] = "-fsanitize-undefined-trap-on-error";
+      cc_params[cc_par_cnt++] = "-fno-sanitize-recover=all";
+      
+    }
 
   }
 


### PR DESCRIPTION
Support to ubsan in afl-clang-fast. I choosed the `-fsanitize=undefined -fsanitize-undefined-trap-on-error -fno-sanitize-recover=all` flags, should be correct.