### PR TITLE
Fix hanging fork and child with -V -E

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,7 +702,7 @@ without feedback, bug reports, or patches from:
   Nathan Voss                           Dominik Maier
   Andrea Biondo                         Vincent Le Garrec
   Khaled Yakdan                         Kuang-che Wu
-  Josephine Calliotte
+  Josephine Calliotte                   Konrad Welc
 ```
 
 Thank you!

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1024,6 +1024,7 @@ int main(int argc, char** argv, char** envp) {
       if (most_time * 1000 < cur_ms_lv - start_time) {
 
         most_time_key = 2;
+        stop_soon = 2;
         break;
 
       }
@@ -1035,6 +1036,7 @@ int main(int argc, char** argv, char** envp) {
       if (most_execs <= total_execs) {
 
         most_execs_key = 2;
+        stop_soon = 2;
         break;
 
       }


### PR DESCRIPTION
If we let multiple fuzzers end with -V or -E option, it will cause it to think we are still occupying the cores, even if they are free, once we try to run another job it would return an error that no free nodes are available.

This change fixes that problem.