### PR TITLE
Fixing 2 little mistakes

### DIFF
--- a/examples/custom_mutators/example.c
+++ b/examples/custom_mutators/example.c
@@ -53,7 +53,7 @@ size_t afl_custom_fuzz(uint8_t *buf, size_t buf_size,
   // Mutate the payload of the packet
   for (int i = 3; i < mutated_size; i++) {
 
-    mutated_out[i] = (data[i] + rand() % 10) & 0xff;
+    mutated_out[i] = (buf[i] + rand() % 10) & 0xff;
 
   }
 
@@ -90,7 +90,7 @@ size_t afl_custom_pre_save(uint8_t *buf, size_t buf_size, uint8_t **out_buf) {
 }
 
 uint8_t *trim_buf;
-size_t trim_buf_size
+size_t trim_buf_size;
 int trimmming_steps;
 int cur_step;
 


### PR DESCRIPTION
This example doesn't compile due to two little errors:
- There is a missing semicolon
- "data" array doesn't exist. I think "buf" should be used instead.