### PR TITLE
fix qemu persistent mode for 32-bit target on 64-bit host

### DIFF
--- a/qemu_mode/patches/afl-qemu-cpu-translate-inl.h
+++ b/qemu_mode/patches/afl-qemu-cpu-translate-inl.h
@@ -35,7 +35,7 @@
 #include "tcg.h"
 #include "tcg-op.h"
 
-#if TCG_TARGET_REG_BITS == 64
+#if TCG_TARGET_LONG_BITS == 64
 #define _DEFAULT_MO MO_64
 #else
 #define _DEFAULT_MO MO_32


### PR DESCRIPTION
When running persistent qemu-mode with CPU_TARGET=i386 on x86_64 host like this:
```sh
AFL_DEBUG_CHILD_OUTPUT=1 AFL_QEMU_PERSISTENT_ADDR=$function_start_addr afl-fuzz -Q -i in -o out -- ./test @@
```
afl aborts with message:
  /AFLplusplus/qemu_mode/qemu-3.1.1/tcg/tcg-op.c:2646: tcg fatal error
  qemu: uncaught target signal 11 (Segmentation fault) - core dumped
This patch fixes the error
