### PR TITLE
Update README.md add install of llvm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ afl++ has many build options.
 The easiest is to build and install everything:
 
 ```shell
-$ sudo apt install build-essential libtool-bin python3 automake bison libglib2.0-dev libpixman-1-dev clang python-setuptools
+$ sudo apt install build-essential libtool-bin python3 automake bison libglib2.0-dev libpixman-1-dev clang python-setuptools llvm
 $ make distrib
 $ sudo make install
 ```


### PR DESCRIPTION
The build and install steps are missing the installation of "llvm" package which is a pre-requisite for building llvm_mode.

Added the "llvm" package in the installation line.